### PR TITLE
adding auth middleware

### DIFF
--- a/controllers/api/itemRoutes.js
+++ b/controllers/api/itemRoutes.js
@@ -6,6 +6,7 @@ dotenv.config();
 // import all models to easily manipulate includes
 // remove unused models before deployment
 import { Customer, Order, Shift, Item } from '../../models/index.js';
+import apiAuth from '../../middleware/apiAuth.js';
 
 const router = express.Router();
 
@@ -45,10 +46,9 @@ router.get('/:id', async (req, res) => {
 });
 
 // POST new item
-router.post('/', async (req, res) => {
+//TODO: replace all auth with this piece of middleware
+router.post('/',apiAuth,  async (req, res) => {
 	try {
-		const token = jwt.verify(req.headers?.authorization, process.env.JWT_SECRET);
-
 		const item = await Item.create(req.body);
 		if (!item) return res.status(400).json({ error: 'This item could not be created.' });
 

--- a/middleware/apiAuth.js
+++ b/middleware/apiAuth.js
@@ -1,0 +1,12 @@
+import jwt from "jsonwebtoken";
+export default function apiAuth(req,res,next){
+    try {
+        console.log(req.headers)
+        const token = jwt.verify(req.headers?.authorization?.split(" ")[1], process.env.JWT_SECRET);
+        req.loggedIn=true;
+        next()
+    } catch{
+        
+        res.status(403).json({msg:"invalid token"})
+    }
+}


### PR DESCRIPTION
Adding auth middleware to streamline authenticated request.  Auth is broken as written, remember that token based auth comes in the auth header as `Bearer {token}`, we weren't stripping the leading `Bearer`.  Use the example in `controllers/api.itemRoutes` line 50 to update auth setups.  